### PR TITLE
Docs: Add Build and Run Instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,28 @@
 # FyneWire
 
 A cross-platform, modular desktop packet sniffer and analyzer written in Go, featuring a modern Fyne GUI, AI-powered filtering via Google Gemini, and high-speed packet decoding with gopacket.
-Features
-
-🚦 **Live packet capture** from any local interface using libpcap (via cgo)
-🖥️ **Native GUI** (Fyne) – fast, cross-platform, and beautiful
-📋 **Protocol decoding** with `gopacket` (Ethernet, IPv4/6, TCP, UDP, etc.)
-🧠 **AI-powered filtering**: enter natural language prompts (“only DNS”, “TCP SYN floods”) and see only matching packets (via Google Gemini)
-🔌 **Plugin architecture**: filter and enrich packets using the `Strategy` and `Decorator` patterns
-🧪 **Unit and UI tests** – including headless Fyne test driver for CI
-🤖 **GitHub Actions CI**: builds, vets, and tests on push
 
 ---
+
+## Features
+
+* 🚦 **Live packet capture** from any local interface using libpcap (via cgo)
+* 🖥️ **Native GUI** (Fyne) – fast, cross-platform, and beautiful
+* 📋 **Protocol decoding** with [gopacket](https://github.com/google/gopacket) (Ethernet, IPv4/6, TCP, UDP, etc.)
+* 🧠 **AI-powered filtering**: enter natural language prompts (“only DNS”, “TCP SYN floods”) and see only matching packets (via Google Gemini)
+* 🔌 **Plugin architecture**: filter and enrich packets using the [Strategy](https://en.wikipedia.org/wiki/Strategy_pattern) and [Decorator](https://en.wikipedia.org/wiki/Decorator_pattern) patterns
+* 🧪 **Unit and UI tests** – including headless Fyne test driver for CI
+* 🤖 **GitHub Actions CI**: builds, vets, and tests on push
+
+---
+
 ## Building and Running
 
 ### Prerequisites
 
 You will need the following installed to build and run FyneWire:
 
-* **Go 1.21+**: Download from [golang.org](https://golang.org/).
+* **Go 1.21+**: Download from [go.dev](https://go.dev/doc/install).
 * **A C Compiler**: Such as GCC, Clang, or the Xcode Command Line Tools.
     * On macOS: `xcode-select --install`
     * On Debian/Ubuntu: `sudo apt-get install build-essential`
@@ -26,7 +30,7 @@ You will need the following installed to build and run FyneWire:
     * On macOS: `brew install libpcap`
     * On Debian/Ubuntu: `sudo apt-get install libpcap-dev`
     * On Fedora/RHEL: `sudo dnf install libpcap-devel`
-* **Google Gemini API Key** (Optional): Required only for the AI filtering feature. You can get a key from [Google AI Studio](https://aistudio.google.com/).
+* **Google Gemini API Key** (Optional): Required only for the AI filtering feature. You can get a key from [Google AI Studio](https://ai.google.dev/).
 
 ### Installation and Execution
 
@@ -55,6 +59,7 @@ You will need the following installed to build and run FyneWire:
         ```
 
 ---
+
 ## Design Overview
 
 * **Multi-layered**: C only exposes raw capture; all parsing/logic is in Go.
@@ -64,19 +69,25 @@ You will need the following installed to build and run FyneWire:
 * **Fyne**: Responsive, cross-platform UI. Data binding keeps lists live.
 * **cgo**: Clean, minimal, and cross-platform for direct libpcap access.
 
+---
+
 ## Testing & CI
 
-* **Unit tests**: Run with `go test ./...`
+* **Unit tests**: Run with `go test ./...`
 * **GUI tests**: Headless mode via Fyne’s test driver.
-* **Continuous Integration**: `GitHub Actions` builds and tests on every push.
+* **Continuous Integration**: [GitHub Actions](.github/workflows/ci.yml) builds and tests on every push.
+
+---
 
 ## Contributing
 
-* Fork and branch!
-* Run `make vet` and `go test ./...` before opening PRs.
-* For new features, keep C glue minimal; extend Go strategies or decorators.
-* For Gemini/AI features, be mindful of API quotas and errors.
+1. Fork and branch!
+2. Run `make vet` and `go test ./...` before opening PRs.
+3. For new features, keep C glue minimal; extend Go strategies or decorators.
+4. For Gemini/AI features, be mindful of API quotas and errors.
+
+---
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,49 +1,60 @@
 # FyneWire
 
 A cross-platform, modular desktop packet sniffer and analyzer written in Go, featuring a modern Fyne GUI, AI-powered filtering via Google Gemini, and high-speed packet decoding with gopacket.
+Features
+
+🚦 **Live packet capture** from any local interface using libpcap (via cgo)
+🖥️ **Native GUI** (Fyne) – fast, cross-platform, and beautiful
+📋 **Protocol decoding** with `gopacket` (Ethernet, IPv4/6, TCP, UDP, etc.)
+🧠 **AI-powered filtering**: enter natural language prompts (“only DNS”, “TCP SYN floods”) and see only matching packets (via Google Gemini)
+🔌 **Plugin architecture**: filter and enrich packets using the `Strategy` and `Decorator` patterns
+🧪 **Unit and UI tests** – including headless Fyne test driver for CI
+🤖 **GitHub Actions CI**: builds, vets, and tests on push
 
 ---
-
-## Features
-
-* 🚦 **Live packet capture** from any local interface using libpcap (via cgo)
-* 🖥️ **Native GUI** (Fyne) – fast, cross-platform, and beautiful
-* 📋 **Protocol decoding** with [gopacket](https://github.com/google/gopacket) (Ethernet, IPv4/6, TCP, UDP, etc.)
-* 🧠 **AI-powered filtering**: enter natural language prompts (“only DNS”, “TCP SYN floods”) and see only matching packets (via Google Gemini)
-* 🔌 **Plugin architecture**: filter and enrich packets using the [Strategy](https://en.wikipedia.org/wiki/Strategy_pattern) and [Decorator](https://en.wikipedia.org/wiki/Decorator_pattern) patterns
-* 🧪 **Unit and UI tests** – including headless Fyne test driver for CI
-* 🤖 **GitHub Actions CI**: builds, vets, and tests on push
-
----
-
-## Quickstart
+## Building and Running
 
 ### Prerequisites
 
-* Go 1.21+ ([Install](https://go.dev/doc/install))
-* libpcap development files (`sudo apt install libpcap-dev` or via Homebrew on macOS)
-* For AI filtering: [Google Gemini API key](https://ai.google.dev/)
-* C compiler (`gcc`, `clang`, or equivalent)
+You will need the following installed to build and run FyneWire:
 
-### Build & Run
+* **Go 1.21+**: Download from [golang.org](https://golang.org/).
+* **A C Compiler**: Such as GCC, Clang, or the Xcode Command Line Tools.
+    * On macOS: `xcode-select --install`
+    * On Debian/Ubuntu: `sudo apt-get install build-essential`
+* **`libpcap` Development Libraries**: This is required for packet capture.
+    * On macOS: `brew install libpcap`
+    * On Debian/Ubuntu: `sudo apt-get install libpcap-dev`
+    * On Fedora/RHEL: `sudo dnf install libpcap-devel`
+* **Google Gemini API Key** (Optional): Required only for the AI filtering feature. You can get a key from [Google AI Studio](https://aistudio.google.com/).
 
-```bash
-git clone https://github.com/arya2004/fynewire.git
-cd fynewire
-make            # builds libsniffer.a and Go modules
-make run        # launches the Fyne GUI
-```
+### Installation and Execution
 
-### Enabling AI Filtering
+1.  **Clone the repository:**
+    ```bash
+    git clone [https://github.com/arya2004/fynewire.git](https://github.com/arya2004/fynewire.git)
+    cd fynewire
+    ```
 
-Set your Gemini API key as an environment variable:
+2.  **Build the application:**
+    The `make` command compiles the required C library and builds the Go application.
+    ```bash
+    make
+    ```
 
-```bash
-export GEMINI_API_KEY="AIzaSy..."
-```
+3.  **Run the application:**
+    Packet sniffing requires elevated privileges.
+    ```bash
+    sudo ./fynewire
+    ```
+    
+    * To use the **AI filtering features**, you must set your API key as an environment variable first. Use the `-E` flag with `sudo` to preserve the variable.
+        ```bash
+        export GEMINI_API_KEY="your-api-key"
+        sudo -E ./fynewire
+        ```
 
 ---
-
 ## Design Overview
 
 * **Multi-layered**: C only exposes raw capture; all parsing/logic is in Go.
@@ -53,27 +64,19 @@ export GEMINI_API_KEY="AIzaSy..."
 * **Fyne**: Responsive, cross-platform UI. Data binding keeps lists live.
 * **cgo**: Clean, minimal, and cross-platform for direct libpcap access.
 
----
-
 ## Testing & CI
 
-* **Unit tests**: Run with `go test ./...`
+* **Unit tests**: Run with `go test ./...`
 * **GUI tests**: Headless mode via Fyne’s test driver.
-* **Continuous Integration**: [GitHub Actions](.github/workflows/ci.yml) builds and tests on every push.
-
----
+* **Continuous Integration**: `GitHub Actions` builds and tests on every push.
 
 ## Contributing
 
-1. Fork and branch!
-2. Run `make vet` and `go test ./...` before opening PRs.
-3. For new features, keep C glue minimal; extend Go strategies or decorators.
-4. For Gemini/AI features, be mindful of API quotas and errors.
-
----
+* Fork and branch!
+* Run `make vet` and `go test ./...` before opening PRs.
+* For new features, keep C glue minimal; extend Go strategies or decorators.
+* For Gemini/AI features, be mindful of API quotas and errors.
 
 ## License
 
-[MIT](LICENSE)
-
-
+MIT


### PR DESCRIPTION
This pull request adds a detailed "Building and Running" section to the README.md file as requested.

The new section includes:
- A complete list of prerequisites for macOS and Linux.
- Step-by-step commands for building the application using `make`.
- Instructions on how to run the application, including the use of `sudo` and how to set the `GEMINI_API_KEY` for AI features.

This change makes it much easier for new users and contributors to get started with the project.

Closes #7